### PR TITLE
Manga chapters post

### DIFF
--- a/tests/integration/test_views.py
+++ b/tests/integration/test_views.py
@@ -1,3 +1,5 @@
+import json
+
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APIClient, APITransactionTestCase
@@ -5,6 +7,7 @@ from tests.factories.chapter import MangaChapterFactory, NovelChapterFactory
 from tests.factories.manga import MangaFactory
 from tests.factories.novel import NovelFactory
 from tests.factories.user import UserFactory
+from unifier.apps.core.models import MangaChapter
 
 
 class MangaViewSetTest(APITransactionTestCase):
@@ -68,6 +71,54 @@ class MangaChapterRetrieveViewSetTest(APITransactionTestCase):
 
         assert status.HTTP_200_OK == response.status_code
         assert ("id", "number", "title", "language", "images",) == tuple(response.json().keys())
+
+
+class MangaChapterCreateViewSetTest(APITransactionTestCase):
+    client = APIClient()
+
+    def setUp(self):
+        self.manga = MangaFactory()
+        self.user = UserFactory()
+        self.token = self.user.auth_token.key
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token}")
+
+        self.dict_payload = {
+            "number": 1,
+            "title": "My dict chapter",
+            "language": 0,
+            "images": ["image 1"],
+            "manga": self.manga.title,
+        }
+        self.list_payload = [
+            {
+                "number": 1,
+                "title": "My list chapter",
+                "language": 0,
+                "images": ["image 1", "image 2"],
+                "manga": self.manga.title,
+            },
+            {
+                "number": 2,
+                "title": "My list chapter 2",
+                "language": 1,
+                "images": ["image 1", "image 2", "image 3"],
+                "manga": self.manga.title,
+            },
+        ]
+
+    def test_create_manga_chapter_passing_dict(self):
+        response = self.client.post(reverse("create-mangachapter-list"), data=self.dict_payload)
+
+        assert status.HTTP_201_CREATED == response.status_code
+        assert 1 == MangaChapter.objects.count()
+
+    def test_create_manga_chapter_passing_list(self):
+        response = self.client.post(
+            reverse("create-mangachapter-list"), json.dumps(self.list_payload), content_type="application/json"
+        )
+
+        assert status.HTTP_201_CREATED == response.status_code
+        assert 2 == MangaChapter.objects.count()
 
 
 class NovelViewSetTest(APITransactionTestCase):

--- a/tests/integration/test_views.py
+++ b/tests/integration/test_views.py
@@ -107,14 +107,16 @@ class MangaChapterCreateViewSetTest(APITransactionTestCase):
         ]
 
     def test_create_manga_chapter_passing_dict(self):
-        response = self.client.post(reverse("create-mangachapter-list"), data=self.dict_payload)
+        response = self.client.post(
+            reverse("create-mangachapter-list"), json.dumps(self.dict_payload), content_type="application/json",
+        )
 
         assert status.HTTP_201_CREATED == response.status_code
         assert 1 == MangaChapter.objects.count()
 
     def test_create_manga_chapter_passing_list(self):
         response = self.client.post(
-            reverse("create-mangachapter-list"), json.dumps(self.list_payload), content_type="application/json"
+            reverse("create-mangachapter-list"), json.dumps(self.list_payload), content_type="application/json",
         )
 
         assert status.HTTP_201_CREATED == response.status_code

--- a/unifier/apps/drf/v1/serializers/__init__.py
+++ b/unifier/apps/drf/v1/serializers/__init__.py
@@ -1,4 +1,5 @@
 from unifier.apps.drf.v1.serializers.manga import (
+    MangaChapterCreateSerializer,
     MangaChapterDetailSerializer,
     MangaChapterSerializer,
     MangaSerializer,

--- a/unifier/apps/drf/v1/serializers/manga.py
+++ b/unifier/apps/drf/v1/serializers/manga.py
@@ -20,6 +20,25 @@ class MangaChapterDetailSerializer(serializers.ModelSerializer):
         fields = MangaChapterSerializer.Meta.fields[:-1] + ["images"]
 
 
+class MangaChapterCreateSerializer(serializers.ModelSerializer):
+    manga = serializers.CharField()
+
+    class Meta:
+        model = MangaChapter
+        fields = [
+            "number",
+            "title",
+            "language",
+            "images",
+            "manga",
+        ]
+
+    def create(self, validated_data):
+        manga = Manga.objects.get(title=validated_data.pop("manga"))
+        instance = MangaChapter.objects.create(**validated_data, manga=manga)
+        return instance
+
+
 class MangaSerializer(serializers.ModelSerializer):
     manga_url = serializers.SerializerMethodField()
 

--- a/unifier/apps/drf/v1/views/__init__.py
+++ b/unifier/apps/drf/v1/views/__init__.py
@@ -1,4 +1,3 @@
-from unifier.apps.drf.v1.views.manga import MangaChapterRetrieveViewSet, MangaViewSet
+from unifier.apps.drf.v1.views.manga import MangaChapterCreateViewSet, MangaChapterRetrieveViewSet, MangaViewSet
 from unifier.apps.drf.v1.views.novel import NovelChapterRetrieveViewSet, NovelViewSet
-from unifier.apps.drf.v1.views.user import UserCreateAPIView
-from unifier.apps.drf.v1.views.user import UserDeleteAPIView
+from unifier.apps.drf.v1.views.user import UserCreateAPIView, UserDeleteAPIView

--- a/unifier/apps/drf/v1/views/manga.py
+++ b/unifier/apps/drf/v1/views/manga.py
@@ -1,8 +1,14 @@
-from rest_framework import mixins, viewsets
+from rest_framework import mixins, status, viewsets
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 from unifier.apps.core.models import Manga, MangaChapter
 from unifier.apps.drf.v1.pagination import BasePagination
-from unifier.apps.drf.v1.serializers import MangaChapterDetailSerializer, MangaSerializer, MangaSerializerDetail
+from unifier.apps.drf.v1.serializers import (
+    MangaChapterCreateSerializer,
+    MangaChapterDetailSerializer,
+    MangaSerializer,
+    MangaSerializerDetail,
+)
 
 
 class MangaViewSet(viewsets.ReadOnlyModelViewSet):
@@ -22,3 +28,17 @@ class MangaChapterRetrieveViewSet(mixins.RetrieveModelMixin, viewsets.GenericVie
     serializer_class = MangaChapterDetailSerializer
     pagination_class = BasePagination
     permission_classes = (IsAuthenticated,)
+
+
+class MangaChapterCreateViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
+    queryset = MangaChapter.objects.all()
+    serializer_class = MangaChapterCreateSerializer
+    permission_classes = (IsAuthenticated,)
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data, many=isinstance(request.data, list))
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        return Response(
+            serializer.data, status=status.HTTP_201_CREATED, headers=self.get_success_headers(serializer.data)
+        )

--- a/unifier/urls.py
+++ b/unifier/urls.py
@@ -4,6 +4,7 @@ from rest_framework.authtoken import views
 from rest_framework.routers import DefaultRouter
 
 from unifier.apps.drf.v1.views import (
+    MangaChapterCreateViewSet,
     MangaChapterRetrieveViewSet,
     MangaViewSet,
     NovelChapterRetrieveViewSet,
@@ -20,6 +21,7 @@ router.register("mangas", MangaViewSet)
 router.register("novels", NovelViewSet)
 router.register("manga-chapter", MangaChapterRetrieveViewSet, basename="manga-chapter")
 router.register("novel-chapter", NovelChapterRetrieveViewSet, basename="novel-chapter")
+router.register("create-mangachapter", MangaChapterCreateViewSet, basename="create-mangachapter")
 
 urlpatterns = [
     path("admin/", admin.site.urls),


### PR DESCRIPTION
# Infos

#### Features of fixes?
- Add route for adding a MangaChapter
- Payload can be a `dict` or `list`

### List example:
```json
[
    {
        "number": 1,
        "title": "My chapter",
        "language": 0,
        "images": [],
        "manga": "Solo Leveling"
    },
    {
        "number": 2,
        "title": "My chapter 2",
        "language": 1,
        "images": ["image 1", "image 2", "image 3"],
        "manga": "Solo Leveling"
    }
]
```
### Dict example:
```json
{
    "number": 1,
    "title": "My chapter",
    "language": 0,
    "images": ["image 1"],
    "manga": "Solo Leveling"
}
```

#### What impacts?
N/A

## Checklist

- [X] Code ready
- [ ] Environment variables added (if necessary)
- [X] Updated / added and working tests
- [X] Fixed lint errors / alerts
