### PR TITLE
Favorite retrieve route

### DIFF
--- a/tests/integration/test_views.py
+++ b/tests/integration/test_views.py
@@ -73,7 +73,13 @@ class MangaChapterRetrieveViewSetTest(APITransactionTestCase):
         response = self.client.get(reverse("manga-chapter-detail", args=[self.manga_chapter.id]))
 
         assert status.HTTP_200_OK == response.status_code
-        assert ("id", "number", "title", "language", "images",) == tuple(response.json().keys())
+        assert (
+            "id",
+            "number",
+            "title",
+            "language",
+            "images",
+        ) == tuple(response.json().keys())
 
 
 class MangaChapterCreateViewSetTest(APITransactionTestCase):
@@ -111,7 +117,9 @@ class MangaChapterCreateViewSetTest(APITransactionTestCase):
 
     def test_create_manga_chapter_passing_dict(self):
         response = self.client.post(
-            reverse("create-mangachapter-list"), json.dumps(self.dict_payload), content_type="application/json",
+            reverse("create-mangachapter-list"),
+            json.dumps(self.dict_payload),
+            content_type="application/json",
         )
 
         assert status.HTTP_201_CREATED == response.status_code
@@ -119,7 +127,9 @@ class MangaChapterCreateViewSetTest(APITransactionTestCase):
 
     def test_create_manga_chapter_passing_list(self):
         response = self.client.post(
-            reverse("create-mangachapter-list"), json.dumps(self.list_payload), content_type="application/json",
+            reverse("create-mangachapter-list"),
+            json.dumps(self.list_payload),
+            content_type="application/json",
         )
 
         assert status.HTTP_201_CREATED == response.status_code
@@ -186,7 +196,13 @@ class NovelChapterRetrieveViewSetTest(APITransactionTestCase):
         response = self.client.get(reverse("novel-chapter-detail", args=[self.novel_chapter.id]))
 
         assert status.HTTP_200_OK == response.status_code
-        assert ("id", "number", "title", "language", "body",) == tuple(response.json().keys())
+        assert (
+            "id",
+            "number",
+            "title",
+            "language",
+            "body",
+        ) == tuple(response.json().keys())
 
 
 class PlatformViewSetTest(APITransactionTestCase):
@@ -335,3 +351,38 @@ class FavoriteApiViewTest(APITransactionTestCase):
 
         assert status.HTTP_400_BAD_REQUEST == response.status_code
         assert response.json()["error"] == "There isn't any favorite linked to this user"
+
+    def test_retrieve_manga_and_novel_favorites(self):
+        response = self.client.get(reverse("favorite"))
+
+        assert status.HTTP_200_OK == response.status_code
+
+        assert len(response.json()["mangas"]) == 1
+        assert len(response.json()["novels"]) == 1
+        assert isinstance(response.json()["mangas"], list)
+        assert isinstance(response.json()["novels"], list)
+        assert (
+            "id",
+            "title",
+            "year",
+            "chapters_count",
+            "author",
+            "description",
+            "rate",
+            "status",
+            "cover",
+            "tags",
+            "manga_url",
+        ) == tuple(response.json()["mangas"][0].keys())
+        assert (
+            "id",
+            "title",
+            "year",
+            "chapters_count",
+            "author",
+            "description",
+            "rate",
+            "status",
+            "cover",
+            "novel_url",
+        ) == tuple(response.json()["novels"][0].keys())

--- a/unifier/apps/core/models/user.py
+++ b/unifier/apps/core/models/user.py
@@ -1,6 +1,6 @@
 from django.db import models
-from unifier.apps.core.models.base import StandardModelMixin
 from unifier.apps.core.models import Manga, Novel, get_user_model
+from unifier.apps.core.models.base import StandardModelMixin
 
 
 class Favorite(StandardModelMixin):

--- a/unifier/apps/drf/v1/serializers/__init__.py
+++ b/unifier/apps/drf/v1/serializers/__init__.py
@@ -1,3 +1,4 @@
+from unifier.apps.drf.v1.serializers.favorite import FavoriteSerializer
 from unifier.apps.drf.v1.serializers.manga import (
     MangaChapterCreateSerializer,
     MangaChapterDetailSerializer,

--- a/unifier/apps/drf/v1/serializers/favorite.py
+++ b/unifier/apps/drf/v1/serializers/favorite.py
@@ -1,0 +1,13 @@
+from rest_framework import serializers
+from unifier.apps.core.models import Favorite
+from unifier.apps.drf.v1.serializers.manga import MangaSerializer
+from unifier.apps.drf.v1.serializers.novel import NovelSerializer
+
+
+class FavoriteSerializer(serializers.ModelSerializer):
+    mangas = MangaSerializer(read_only=True, many=True)
+    novels = NovelSerializer(read_only=True, many=True)
+
+    class Meta:
+        model = Favorite
+        fields = ["mangas", "novels"]

--- a/unifier/apps/drf/v1/views/favorite.py
+++ b/unifier/apps/drf/v1/views/favorite.py
@@ -4,11 +4,18 @@ from rest_framework import generics, status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from unifier.apps.core.models import Favorite, Manga, Novel
+from unifier.apps.drf.v1.pagination import BasePagination
+from unifier.apps.drf.v1.serializers import FavoriteSerializer
 
 
-class FavoriteApiView(generics.CreateAPIView, generics.DestroyAPIView):
+class FavoriteApiView(generics.RetrieveAPIView, generics.CreateAPIView, generics.DestroyAPIView):
     queryset = Favorite.objects.all()
+    pagination_class = BasePagination
     permission_classes = (IsAuthenticated,)
+
+    def get(self, request, *args, **kwargs):
+        serializer = FavoriteSerializer(request.user.favorite)
+        return Response(data=serializer.data, status=status.HTTP_200_OK)
 
     def create(self, request, *args, **kwargs):
         manga = Manga.objects.get_or_none(id=request.data["id"])

--- a/unifier/urls.py
+++ b/unifier/urls.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.urls import include, path
+from django.views.generic.base import RedirectView
 from rest_framework.authtoken import views
 from rest_framework.routers import DefaultRouter
 
@@ -27,6 +28,7 @@ router.register("novel-chapter", NovelChapterRetrieveViewSet, basename="novel-ch
 router.register("create-mangachapter", MangaChapterCreateViewSet, basename="create-mangachapter")
 
 urlpatterns = [
+    path("", RedirectView.as_view(url="/admin")),
     path("admin/", admin.site.urls),
     path("api-auth/", include("rest_framework.urls")),
     path("api/v1/auth-token/", views.obtain_auth_token, name="auth-token"),


### PR DESCRIPTION
# Infos

#### Features of fixes?
- Add `get` route for favorite Mangas and Novels. The payload return is the same as the main page (with id and such)
- Add redirect from `/` to `/admin`

#### What impacts?
N/A

## Checklist

- [X] Code ready
- [ ] Environment variables added (if necessary)
- [X] Updated / added and working tests
- [X] Fixed lint errors / alerts
